### PR TITLE
Bugfix/item.filetype nil

### DIFF
--- a/lua/cmp_yanky.lua
+++ b/lua/cmp_yanky.lua
@@ -13,7 +13,7 @@ function M:complete(request, callback)
 		history = vim.tbl_filter(function(item) return item.filetype == currentFt end, history)
 	end
 
-	local seenItems = {} 
+	local seenItems = {}
 
 	history = vim.tbl_map(function(item)
 		-- avoid duplicated items showing up

--- a/lua/cmp_yanky.lua
+++ b/lua/cmp_yanky.lua
@@ -26,10 +26,11 @@ function M:complete(request, callback)
 		if #label > labelMaxLen then label = label:sub(1, labelMaxLen) .. "…" end
 
 		-- syntax highlighting of full content in the documentation window
+		local ft = item.filetype and item.filetype or ""
 		local docs = {
 			kind = "markdown",
 			value = table.concat({
-				"```" .. item.filetype,
+				"```" .. ft,
 				item.regcontents,
 				"```",
 			}, "\n"),


### PR DESCRIPTION
## Checklist
- [ x] Used only camelCase variable names.
- [ x] If functionality is added or modified, also made respective changes to the readme.
- [ x] Used conventional commits keywords.

Fixes error `cmp_yanky.lua:32: attempt to concatenate field 'filetype' (a nil value)` when using the configuration:

```lua
{
  name = "cmp_yanky",
  option = {
    onlyCurrentFiletype = false
  }
}
```